### PR TITLE
Auto Update

### DIFF
--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -3,9 +3,55 @@
 <head>
 	<meta content='width=device-width' name='viewport'>
 	<title>WLED Update</title>
+	<script src="common.js" type="text/javascript"></script>
 	<script>
 		function B() { window.history.back(); }
 		function U() { document.getElementById("uf").style.display="none";document.getElementById("msg").style.display="block"; }
+		async function autoUpdate() {
+			const btn = gId('autoUpdBtn');
+			const status = gId('autoUpdStatus');
+			btn.disabled = true;
+			status.textContent = '';
+			try {
+				status.textContent = 'Fetching device info...';
+				const infoResp = await fetch(getURL('/json/info'));
+				if (!infoResp.ok) throw new Error('Failed to fetch device info');
+				const info = await infoResp.json();
+				if (!info || !info.repo || info.repo === 'unknown') {
+					status.textContent = 'No release repository available for this build.';
+					btn.disabled = false;
+					return;
+				}
+				status.textContent = 'Checking GitHub for latest release...';
+				const ghResp = await fetch(`https://api.github.com/repos/${info.repo}/releases/latest`);
+				if (!ghResp.ok) throw new Error(`GitHub API error: ${ghResp.status}`);
+				const ghRelease = await ghResp.json();
+				const releaseVer = ghRelease.tag_name.replace(/^v/, '');
+				const assetSuffix = `_${releaseVer}_${info.release}.bin`;
+				const asset = ghRelease.assets.find(a => a.name.endsWith(assetSuffix));
+				if (!asset) {
+					const available = ghRelease.assets.map(a => a.name).join(', ');
+					status.textContent = `Firmware not found (*${assetSuffix}). Available: ${available}`;
+					btn.disabled = false;
+					return;
+				}
+				status.textContent = `Downloading ${asset.name} (${Math.round(asset.size/1024)} KB)...`;
+				const fwUrl = asset.browser_download_url.replace(/^https?:\/\/[^/]+/, 'https://download.wled.me');
+				const fwResp = await fetch(fwUrl);
+				if (!fwResp.ok) throw new Error(`Download failed: ${fwResp.status}`);
+				const blob = await fwResp.blob();
+				const file = new File([blob], asset.name, {type: 'application/octet-stream'});
+				const dt = new DataTransfer();
+				dt.items.add(file);
+				document.querySelector('input[name="update"]').files = dt.files;
+				status.textContent = `Downloaded ${asset.name}. Uploading to device...`;
+				U();
+				gId('uf').submit();
+			} catch(e) {
+				status.textContent = 'Auto-update failed: ' + e.message;
+				btn.disabled = false;
+			}
+		}
 		function GetV() {/*injected values here*/}
 	</script>
 	<style>
@@ -19,6 +65,9 @@
 		Installed version: <span class="sip">WLEDMM ##VERSION##</span><br> <!--WLEDMM: show bin name-->
 		Download the latest release: <a href="https://github.com/MoonModules/WLED-MM/releases/latest" target="_blank" rel="noopener noreferrer">
 		<img src="https://img.shields.io/github/release/MoonModules/WLED-MM.svg?style=flat-square"></a><br>
+		<button type="button" id="autoUpdBtn" onclick="autoUpdate()">Auto update</button><br>
+		<span id="autoUpdStatus" style="display:block;margin-top:4px;font-size:13px;"></span>
+		<hr>
 		<input type='file' name='update' required><br> <!--should have accept='.bin', but it prevents file upload from android app-->
 		<button type="submit">Update!</button><br>
 		<button type="button" onclick="B()">Back</button>


### PR DESCRIPTION
This pull request adds an automatic firmware update feature to the WLED update page, allowing users to update their device firmware directly from the web interface with a single click. The update process fetches the latest release from GitHub, downloads the appropriate firmware binary, and uploads it to the device, providing real-time status updates to the user.

**New auto-update functionality:**

- Added a new `autoUpdate()` JavaScript function in `update.htm` that:
  - Fetches device info to determine the correct firmware repository.
  - Checks GitHub for the latest release and matches the appropriate firmware binary.
  - Downloads the firmware and automatically uploads it to the device, updating the user on progress and errors.

- Introduced a new "Auto update" button and status display to the update page UI, enabling users to trigger the auto-update process and view progress or error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic firmware updates: Added an "Auto update" button in the update interface that automatically checks for and retrieves the latest firmware release available, downloads it, and installs it without requiring manual intervention. The feature displays status messages throughout the entire update process and notifies you with an error message if the update fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->