### PR TITLE
Define custom pin mappings in wled.h

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -105,6 +105,7 @@ default_envs =
   esp32S3_8MB_PSRAM_M_qspi ;; for S3 with 8MB flash, 2 or 4MB PSRAM, HUB75 supported
   esp32S3_8MB_PSRAM_M_opi  ;; for S3 with 8MB flash, 8 or 16MB PSRAM, HUB75 supported
   ;;  === esp32-S3  === with 16MB flash
+  esp32s3_16MB_OPI
   esp32S3_16MB_PSRAM_M_HUB75  ;; for S3 with 16MB flash, HUB75 supported (MOONHUB HUB75 adapter board)
   esp32S3_WROOM-2_M        ;; for S3 WROOM-2; HUB75 supported
   ;;

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 
 # CI binaries
 ;; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth # ESP32 variant builds are temporarily excluded from CI due to toolchain issues on the GitHub Actions Linux environment
-; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi
+; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_16MB_PSRAM_opi
 
 # Release binaries
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,11 +11,10 @@
 
 # CI binaries
 ;; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth # ESP32 variant builds are temporarily excluded from CI due to toolchain issues on the GitHub Actions Linux environment
-; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_16MB_PSRAM_opi
+; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi, esp32s3dev_16MB_PSRAM_opi
 
 # Release binaries
-; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB
-
+; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_8M, esp32s3dev_16MB
 # Build everything
 ; default_envs = esp32dev, esp8285_4CH_MagicHome, codm-controller-0_6-rev2, codm-controller-0_6, esp32s2_saola, d1_mini_5CH_Shojo_PCB, d1_mini, sp501e, nodemcuv2, esp32_eth, anavi_miracle_controller, esp07, esp01_1m_full, m5atom, h803wf, d1_mini_ota, heltec_wifi_kit_8, esp8285_H801, d1_mini_debug, wemos_shield_esp32, elekstube_ips
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,7 @@
 ; default_envs = esp32c3dev
 ; default_envs = lolin_s2_mini
 ; default_envs = esp32s3dev_16MB_PSRAM_opi
+; default_envs = esp32s3_16MB_OPI
 
 ; MoonModules entries
 ; ===================

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -1,3 +1,20 @@
+#ifndef WLED_MY_PINS
+#define WLED_MY_PINS
+#define R1_PIN  42
+#define G1_PIN  41
+#define B1_PIN  40
+#define R2_PIN  39
+#define G2_PIN  38
+#define B2_PIN  45
+#define A_PIN   1
+#define B_PIN   2
+#define C_PIN   3
+#define D_PIN   4
+#define E_PIN   5
+#define LAT_PIN 6
+#define OE_PIN  7
+#define CLK_PIN 8
+#endif
 #ifndef WLED_H
 #define WLED_H
 /*

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -1,19 +1,19 @@
 #ifndef WLED_MY_PINS
 #define WLED_MY_PINS
-#define R1_PIN  42
-#define G1_PIN  41
-#define B1_PIN  40
-#define R2_PIN  39
-#define G2_PIN  38
-#define B2_PIN  45
-#define A_PIN   1
-#define B_PIN   2
-#define C_PIN   3
-#define D_PIN   4
-#define E_PIN   5
-#define LAT_PIN 6
-#define OE_PIN  7
-#define CLK_PIN 8
+#define R1_PIN 4
+#define G1_PIN 5
+#define B1_PIN 6
+#define R2_PIN 7
+#define G2_PIN 15
+#define B2_PIN 16
+#define A_PIN 8
+#define B_PIN 9
+#define C_PIN 10
+#define D_PIN 11
+#define E_PIN 12
+#define LAT_PIN 13
+#define OE_PIN 14
+#define CLK_PIN 17
 #endif
 #ifndef WLED_H
 #define WLED_H


### PR DESCRIPTION
Matrixboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated compile-time LED GPIO pin mappings to support two separate RGB LED channel groups.
  * Added/extended additional LED control and display-related GPIO assignments.

* **Build**
  * Expanded the configured default firmware build environments to include the ESP32-S3 (16MB OPI) target.
  * Updated build environment naming in examples (ESP32-S3 8MB) and added an optional single-binary example for ESP32-S3 (16MB OPI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->