### PR TITLE
Add generic usermod palette support, move AR palettes to usermod

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1219,7 +1219,7 @@ AR_build_flags =
   ;; NOTE: External repo needs library.json updated with "srcFilter": ["-<*>"] to prevent .cpp compilation
 AR_lib_deps =
   https://github.com/netmindz/WLED-AudioReactive-Usermod#06326b0cfab1fbb9c5756322d25b3bc412259ffa ;; AR color palettes moved into usermod
-  ;; arduinoFFT is now pulled in via the usermod's own library.json (kosme/arduinoFFT @ 2.0.1)
+  https://github.com/softhack007/arduinoFFT.git#56c867ca89341cf23ad8704d3b928e65bc445734 ;;  @ 1.9.2 used for USERMOD_AUDIOREACTIVE - optimized version, 10% faster on -S2/-C3 (long hash: pioarduino has problems with short hashes)
 
 animartrix_build_flags = -D USERMOD_ANIMARTRIX ;; WLEDMM usermod: CC BY-NC 3.0 licensed effects by Stefan Petrick
 animartrix_lib_deps = https://github.com/netmindz/animartrix.git#81eb09b91c8c9c8c01f8ea442787f8127d56c72f ;; custom PSRAM allocator

--- a/platformio.ini
+++ b/platformio.ini
@@ -1218,8 +1218,8 @@ AR_build_flags =
   ;; WLEDMM audioreactive usermod, licensed under EUPL-1.2
   ;; NOTE: External repo needs library.json updated with "srcFilter": ["-<*>"] to prevent .cpp compilation
 AR_lib_deps =
-  https://github.com/MoonModules/WLED-AudioReactive-Usermod#171c0bbc2bc47e2c11ae203dd00beed82865df2b ;; broadcast
-  https://github.com/softhack007/arduinoFFT.git#56c867c ;;  @ 1.9.2 used for USERMOD_AUDIOREACTIVE - optimized version, 10% faster on -S2/-C3
+  https://github.com/netmindz/WLED-AudioReactive-Usermod#06326b0cfab1fbb9c5756322d25b3bc412259ffa ;; AR color palettes moved into usermod
+  ;; arduinoFFT is now pulled in via the usermod's own library.json (kosme/arduinoFFT @ 2.0.1)
 
 animartrix_build_flags = -D USERMOD_ANIMARTRIX ;; WLEDMM usermod: CC BY-NC 3.0 licensed effects by Stefan Petrick
 animartrix_lib_deps = https://github.com/netmindz/animartrix.git#81eb09b91c8c9c8c01f8ea442787f8127d56c72f ;; custom PSRAM allocator

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -1094,7 +1094,8 @@ class WS2812FX {  // 96 bytes
     inline uint8_t getTargetFps()  const { return _targetFps; }
     inline uint8_t getModeCount()  const { return _modeCount; }
     inline static constexpr uint8_t getMaxSegments(void)  { return MAX_NUM_SEGMENTS; }  // returns maximum number of supported segments (fixed value)
-    inline static constexpr uint8_t getPaletteCount()  { return 13 + GRADIENT_PALETTE_COUNT; }  // will only return built-in palette count
+    // WLEDMM: total palette count = fixed built-ins + user custom palettes + usermod-registered palettes (matches upstream WLED's getPaletteCount(), PR #5548)
+    inline uint8_t getPaletteCount()  const { return (uint8_t)(FIXED_PALETTE_COUNT + customPalettes.size() + usermodPalettes.size()); }
 
     uint16_t
       ablMilliampsMax,

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -356,8 +356,20 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) c
   static CRGBPalette16 randomPalette = CRGBPalette16(DEFAULT_COLOR);
   static CRGBPalette16 prevRandomPalette = CRGBPalette16(CRGB(BLACK));
   byte tcp[76] = { 255 };   //WLEDMM: prevent out-of-range access in loadDynamicGradientPalette()
-  if (pal < 245 && pal > GRADIENT_PALETTE_COUNT+13) pal = 0;
-  if (pal > 245 && (strip.customPalettes.size() == 0 || 255U-pal > strip.customPalettes.size()-1)) pal = 0; // TODO remove strip dependency by moving customPalettes out of strip
+  // there is one randomly generated palette (1) followed by 4 palettes created from segment colors (2-5)
+  // those are followed by 7 fastled palettes (6-12), 58 gradient palettes (13-70) and WLEDMM's "* Random Cycle" (71)
+  // then come user custom palettes (IDs <=200) and usermod palettes (IDs 201-255), both growing downward from their respective base IDs
+  // (matches upstream WLED's palette ID layout, PR #5548, adapted to WLEDMM's own fixed-palette set)
+  const int umCount   = usermodPalettes.size();
+  const int custCount = strip.customPalettes.size(); // TODO remove strip dependency by moving customPalettes out of strip
+  if (pal >= FIXED_PALETTE_COUNT) {
+    if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod range (IDs 201-255)
+      if ((int)(WLED_USERMOD_PALETTE_ID_BASE - pal) >= umCount) pal = 0;
+    } else { // custom range (IDs 72-200)
+      if ((int)(WLED_CUSTOM_PALETTE_ID_BASE - pal) >= custCount) pal = 0;
+    }
+  }
+
   //default palette. Differs depending on effect
   if (pal == 0) switch (mode) {
     case FX_MODE_FIRE_2012  : pal = 35; break; // heat palette
@@ -395,7 +407,7 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) c
         targetPalette[i].b = prevRandomPalette[i].b*(5000-timeSinceLastChange)/5000 + randomPalette[i].b*timeSinceLastChange/5000;
       }
       break;}
-    case 74: {//periodically replace palette with a random one. Transition palette change in 500ms
+    case 71: {//WLEDMM "* Random Cycle": periodically replace palette with a random one. Transition palette change in 500ms
       uint32_t timeSinceLastChange = millis() - _lastPaletteChange;
       if (timeSinceLastChange > randomPaletteChangeTime * 1000U) {
         prevRandomPalette = randomPalette;
@@ -454,13 +466,11 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) c
       targetPalette = RainbowColors_p; break;
     case 12: //Rainbow stripe colors
       targetPalette = RainbowStripeColors_p; break;
-    case 71: //WLEDMM netmindz ar palette +1
-    case 72: //WLEDMM netmindz ar palette +2
-    case 73: //WLEDMM netmindz ar palette +3
-        targetPalette.loadDynamicGradientPalette(getAudioPalette(pal)); break; 
     default: //progmem palettes
-      if (pal>245) {
-        targetPalette = strip.customPalettes[255-pal]; // we checked bounds above
+      if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod palette (IDs 201-255)
+        targetPalette = usermodPalettes[WLED_USERMOD_PALETTE_ID_BASE - pal].palette;
+      } else if (pal >= FIXED_PALETTE_COUNT) { // user custom palette (IDs 72-200)
+        targetPalette = strip.customPalettes[WLED_CUSTOM_PALETTE_ID_BASE - pal];
       } else {
         memcpy_P(tcp, (byte*)pgm_read_dword(&(gGradientPalettes[pal-13])), 72);
         targetPalette.loadDynamicGradientPalette(tcp);
@@ -469,6 +479,7 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) c
   }
   return targetPalette;
 }
+
 
 void Segment::startTransition(uint16_t dur) {
   if (transitional || _t) return; // already in transition no need to store anything
@@ -680,8 +691,14 @@ void Segment::setMode(uint8_t fx, bool loadDefaults, bool sliderDefaultsOnly) {
 }
 
 void Segment::setPalette(uint8_t pal) {
-  if (pal < 245 && pal > GRADIENT_PALETTE_COUNT+13) pal = 0; // built in palettes
-  if (pal > 245 && (strip.customPalettes.size() == 0 || 255U-pal > strip.customPalettes.size()-1)) pal = 0; // custom palettes
+  if (pal >= FIXED_PALETTE_COUNT) {
+    if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod range (IDs 201-255)
+      if ((int)(WLED_USERMOD_PALETTE_ID_BASE - pal) >= (int)usermodPalettes.size()) pal = 0;
+    } else { // custom range (IDs 72-200)
+      if ((int)(WLED_CUSTOM_PALETTE_ID_BASE - pal) >= (int)strip.customPalettes.size()) pal = 0;
+    }
+  }
+
   if (pal != palette) {
     if (strip.paletteFade && on) startTransition(strip.getTransition());
     palette = pal;
@@ -1659,45 +1676,6 @@ uint8_t Segment::get_random_wheel_index(uint8_t pos) const { // WLEDMM use fast 
  * @returns Single color from palette
  */
 // WLEDMM: Segment::color_from_palette() moved to FX.h for better optimization by the compiler
-
- //WLEDMM netmindz ar palette
-uint8_t * Segment::getAudioPalette(int pal) const {
-  // https://forum.makerforums.info/t/hi-is-it-possible-to-define-a-gradient-palette-at-runtime-the-define-gradient-palette-uses-the/63339
-  
-  um_data_t *um_data;
-  if (!usermods.getUMData(&um_data, USERMOD_ID_AUDIOREACTIVE)) {
-    um_data = simulateSound(SEGMENT.soundSim);
-  }
-  uint8_t *fftResult = (uint8_t*)um_data->u_data[2];
-
-  static uint8_t xyz[16];  // Needs to be 4 times however many colors are being used.
-                           // 3 colors = 12, 4 colors = 16, etc.
-
-  xyz[0] = 0;  // anchor of first color - must be zero
-  xyz[1] = 0;
-  xyz[2] = 0;
-  xyz[3] = 0;
-  
-  CRGB rgb = getCRGBForBand(1, fftResult, pal);
-  xyz[4] = 1;  // anchor of first color
-  xyz[5] = rgb.r;
-  xyz[6] = rgb.g;
-  xyz[7] = rgb.b;
-  
-  rgb = getCRGBForBand(128, fftResult, pal);
-  xyz[8] = 128;
-  xyz[9] = rgb.r;
-  xyz[10] = rgb.g;
-  xyz[11] = rgb.b;
-  
-  rgb = getCRGBForBand(255, fftResult, pal);
-  xyz[12] = 255;  // anchor of last color - must be 255
-  xyz[13] = rgb.r;
-  xyz[14] = rgb.g;
-  xyz[15] = rgb.b;
-
-  return xyz;
-}
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2768,7 +2746,6 @@ bool WS2812FX::deserializeMap(uint8_t n) {
 WS2812FX* WS2812FX::instance = nullptr;
 
 const char JSON_mode_names[] PROGMEM = R"=====(["FX names moved"])=====";
- //WLEDMM netmindz ar palette add Audio responsive
 const char JSON_palette_names[] PROGMEM = R"=====([
 "Default","* Random Smooth ☾","* Color 1","* Colors 1&2","* Color Gradient","* Colors Only","Party","Cloud","Lava","Ocean",
 "Forest","Rainbow","Rainbow Bands","Sunset","Rivendell","Breeze","Red & Blue","Yellowout","Analogous","Splash",
@@ -2777,5 +2754,5 @@ const char JSON_palette_names[] PROGMEM = R"=====([
 "Magenta","Magred","Yelmag","Yelblu","Orange & Teal","Tiamat","April Night","Orangery","C9","Sakura",
 "Aurora","Atlantica","C9 2","C9 New","Temperature","Aurora 2","Retro Clown","Candy","Toxy Reaf","Fairy Reaf",
 "Semi Blue","Pink Candy","Red Reaf","Aqua Flash","Yelblu Hot","Lite Light","Red Flash","Blink Red","Red Shift","Red Tide",
-"Candy2","Audio Responsive Ratio ☾","Audio Responsive Hue ☾","Audio Responsive Ramp ☾","* Random Cycle"
+"Candy2","* Random Cycle"
 ])=====";

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2231,8 +2231,10 @@ void WS2812FX::setMainSegmentId(uint8_t n) {
 }
 
 uint8_t WS2812FX::getLastActiveSegmentId(void) const {
-  for (size_t i = _segments.size() -1; i > 0; i--) {
-    if (_segments[i].isActive()) return i;
+  if (_segments.size() > 0) { // WLEDMM prevent unsigned wrap-around when _segments.size() < 1
+    for (size_t i = _segments.size() -1; i > 0; i--) {
+      if (_segments[i].isActive()) return i;
+    }
   }
   return 0;
 }

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -504,3 +504,14 @@ IRAM_ATTR_YN uint32_t __attribute__((hot)) gamma32(uint32_t color)
   return RGBW32(r, g, b, w);
 }
 #endif
+
+// WLEDMM: removes all palette entries registered by the usermod identified by `name` (pointer identity match,
+// matching upstream WLED's wled00/colors.cpp removeUsermodPalettes(), PR #5548). Returns the number removed.
+size_t removeUsermodPalettes(const char *name) {
+  size_t before = usermodPalettes.size();
+  for (int i = (int)usermodPalettes.size() - 1; i >= 0; i--) {
+    if (usermodPalettes[i].name == name)
+      usermodPalettes.erase(usermodPalettes.begin() + i);
+  }
+  return before - usermodPalettes.size();
+}

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -76,6 +76,20 @@ struct CRGBW {
 
 #endif
 
+// WLEDMM: Palette registered by a usermod at fixed IDs (255, 254, 253... 201), growing downward from WLED_USERMOD_PALETTE_ID_BASE.
+// Display name is "name: palName" (if palName non-null) or falls back to "name index" (e.g. "AudioReactive 1"), see util.cpp
+// (matches upstream WLED's wled00/colors.h UsermodPalette, PR #5548)
+struct UsermodPalette {
+  CRGBPalette16 palette;
+  const char   *name;      // PROGMEM base name string (must not be nullptr), used as identity key by removeUsermodPalettes()
+  uint8_t       palIndex;  // index of the palette for a usermod
+  const char   *palName;   // optional PROGMEM display name; "name: palName" if set, else "name index"
+};
+
+// Remove all entries from usermodPalettes whose name pointer matches 'name'. Returns number of entries removed.
+size_t removeUsermodPalettes(const char *name);
+extern std::vector<UsermodPalette> usermodPalettes; // usermod-registered palettes (IDs 255, 254, 253...), see wled.h
+
 
 struct CHSV32 { // 32bit HSV color with 16bit hue for more accurate conversions - credits @dedehai
   union {

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -5,7 +5,26 @@
  * Readability defines and their associated numerical values + compile-time constants
  */
 
-#define GRADIENT_PALETTE_COUNT 62 //WLEDMM netmindz ar palette +3, ewowi Random Smooth palette +1
+constexpr size_t FASTLED_PALETTE_COUNT = 7;   //  6-12 = sizeof(fastledPalettes) / sizeof(fastledPalettes[0]);
+constexpr size_t GRADIENT_PALETTE_COUNT = 58; // 13-70 = sizeof(gGradientPalettes) / sizeof(gGradientPalettes[0]);
+constexpr size_t DYNAMIC_PALETTE_COUNT = 6;   //  0- 5 = dynamic palettes (0=default(virtual),1=random,2=primary,3=primary+secondary,4=primary+secondary+tertiary,5=primary+secondary(+tertiary if not black)
+constexpr size_t WLEDMM_EXTRA_PALETTE_COUNT = 1; // 71 = "* Random Cycle" WLEDMM extra (in addition to upstream's "Random Smooth" at id 1)
+constexpr size_t FIXED_PALETTE_COUNT = DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT + GRADIENT_PALETTE_COUNT + WLEDMM_EXTRA_PALETTE_COUNT; // total number of fixed palettes (=72)
+
+// Palette ID space layout (palette IDs are uint8_t, 0-255):
+//   0  .. FIXED_PALETTE_COUNT-1            : fixed built-in palettes (WLEDMM: includes "* Random Cycle" at 71)
+//   72 .. WLED_CUSTOM_PALETTE_ID_BASE(200) : user custom palettes (index 0 = ID 200, growing downward)
+//   201.. WLED_USERMOD_PALETTE_ID_BASE(255): usermod-registered palettes (index 0 = ID 255, growing downward)
+constexpr uint8_t WLED_USERMOD_PALETTE_ID_BASE = 255; // highest ID for usermod palettes
+constexpr uint8_t WLED_CUSTOM_PALETTE_ID_BASE  = 200; // highest ID for user custom palettes
+constexpr size_t  WLED_MAX_USERMOD_PALETTES     = WLED_USERMOD_PALETTE_ID_BASE - WLED_CUSTOM_PALETTE_ID_BASE; // 55 slots (IDs 201-255)
+#ifndef ESP8266
+  #define WLED_MAX_CUSTOM_PALETTES (WLED_CUSTOM_PALETTE_ID_BASE - FIXED_PALETTE_COUNT + 1) // 129 slots (IDs 72-200)
+#else
+  #define WLED_MAX_CUSTOM_PALETTES 10 // ESP8266: limit custom palettes to 10
+#endif
+#define WLED_MAX_CUSTOM_PALETTE_GAP 20 // max number of empty palette files in a row before stopping to look for more (20 takes 100ms)
+
 
 //Defaults
 #define DEFAULT_CLIENT_SSID "Your_Network"

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -986,17 +986,35 @@ function populatePalettes()
 		);
 	}
 	gId('pallist').innerHTML=html;
-	// append custom palettes (when loading for the 1st time)
-	if (!isEmpty(lastinfo) && lastinfo.cpalcount) {
-		for (let j = 0; j<lastinfo.cpalcount; j++) {
+	// append usermod palettes (fixed ID space: 255 down to 201)
+	let li = lastinfo;
+	if (!isEmpty(li) && li.umpalcount && li.umpalnames) {
+		for (let j = 0; j < li.umpalcount; j++) {
 			let div = d.createElement("div");
 			gId('pallist').appendChild(div);
 			div.outerHTML = generateListItemHtml(
 				'palette',
 				255-j,
-				'~ Custom '+j+' ~',
+				li.umpalnames[j],
 				'setPalette',
 				`<div class="lstIprev" style="${genPalPrevCss(255-j)}"></div>`
+			);
+		}
+	}
+	// append user custom palettes (fixed ID space: 200 down to FIXED_PALETTE_COUNT+1)
+	if (!isEmpty(li) && li.cpalcount) {
+		for (let j = 0; j < li.cpalcount; j++) {
+			const id = 200 - j;
+			const pd = palettesData[id];
+			if (pd && pd.length === 16 && pd.every(e => e[1] === 128 && e[2] === 128 && e[3] === 128)) continue; // skip gray gap-placeholder entries
+			let div = d.createElement("div");
+			gId('pallist').appendChild(div);
+			div.outerHTML = generateListItemHtml(
+				'palette',
+				id,
+				'~ Custom '+j+' ~',
+				'setPalette',
+				`<div class="lstIprev" style="${genPalPrevCss(id)}"></div>`
 			);
 		}
 	}
@@ -3449,7 +3467,7 @@ function loadPalettesData(callback = null)
 	if (lsPalData) {
 		try {
 			var d = JSON.parse(lsPalData);
-			if (d && d.vid == d.vid) {
+			if (d && d.vid == lastinfo.vid && d.pcount == lastinfo.palcount) { // WLEDMM: also invalidate cache if total palette count changed (fixes upstream bug where vid alone was compared to itself)
 				palettesData = d.p;
 				if (callback) callback();
 				return;
@@ -3461,8 +3479,10 @@ function loadPalettesData(callback = null)
 	getPalettesData(0, ()=>{
 		localStorage.setItem(lsKey, JSON.stringify({
 			p: palettesData,
-			vid: lastinfo.vid
+			vid: lastinfo.vid,
+			pcount: lastinfo.palcount // WLEDMM: total palette count, used to invalidate stale cache
 		}));
+
 		redrawPalPrev();
 		if (callback) setTimeout(callback, 99);
 	});

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1064,6 +1064,18 @@ void serializeInfo(JsonObject root)
   root[F("fxcount")] = strip.getModeCount();
   root[F("palcount")] = strip.getPaletteCount();
   root[F("cpalcount")] = strip.customPalettes.size(); //number of custom palettes
+  root[F("umpalcount")] = usermodPalettes.size(); // number of usermod-registered palettes
+  root[F("cpalmax")] = WLED_MAX_CUSTOM_PALETTES;  // maximum number of custom palettes
+  // send usermod palette names so the UI can label them correctly
+  if (usermodPalettes.size() > 0) {
+    JsonArray umpalnames = root.createNestedArray(F("umpalnames"));
+    for (size_t j = 0; j < usermodPalettes.size(); j++) {
+      char buf[34];
+      extractModeName(WLED_USERMOD_PALETTE_ID_BASE - j, JSON_palette_names, buf, sizeof(buf) - 1);
+      umpalnames.add(buf);
+    }
+  }
+
 
   JsonArray ledmaps = root.createNestedArray(F("maps"));
   for (size_t i=0; i<WLED_MAX_LEDMAPS; i++) {
@@ -1352,21 +1364,31 @@ void serializePalettes(JsonObject root, AsyncWebServerRequest* request)
     page = request->getParam("page")->value().toInt();
   }
 
-  int palettesCount = strip.getPaletteCount();
-  int customPalettes = strip.customPalettes.size();
+  const int customPalettesCount = strip.customPalettes.size();
+  const int umPalettesCount     = usermodPalettes.size();
+  const int palettesCount       = strip.getPaletteCount() - customPalettesCount - umPalettesCount; // fixed built-in palette count
 
-  int maxPage = (palettesCount + customPalettes -1) / itemPerPage;
+  int maxPage = (palettesCount + umPalettesCount + customPalettesCount -1) / itemPerPage;
   if (page > maxPage) page = maxPage;
 
   int start = itemPerPage * page;
-  int end = start + itemPerPage;
-  if (end > palettesCount + customPalettes) end = palettesCount + customPalettes;
+  int end = min(start + itemPerPage, palettesCount + umPalettesCount + customPalettesCount);
+
 
   root[F("m")] = maxPage; // inform caller how many pages there are
   JsonObject palettes  = root.createNestedObject("p");
 
   for (int i = start; i < end; i++) {
-    JsonArray curPalette = palettes.createNestedArray(String(i>=palettesCount ? 255 - i + palettesCount : i));
+    // compute the palette ID for this sequential index
+    int paletteId;
+    if (i >= palettesCount + umPalettesCount) // user custom palette (IDs 200, 199, ...)
+      paletteId = WLED_CUSTOM_PALETTE_ID_BASE - (i - palettesCount - umPalettesCount);
+    else if (i >= palettesCount)              // usermod palette (IDs 255, 254, ...)
+      paletteId = WLED_USERMOD_PALETTE_ID_BASE - (i - palettesCount);
+    else
+      paletteId = i;                          // fixed palette
+    JsonArray curPalette = palettes.createNestedArray(String(paletteId));
+
     switch (i) {
       case 0: //default palette
         setPaletteColors(curPalette, PartyColors_p);
@@ -1377,7 +1399,7 @@ void serializePalettes(JsonObject root, AsyncWebServerRequest* request)
           curPalette.add("r");
           curPalette.add("r");
         break;
-      case 74: //WLEDMM random AC
+      case 71: //WLEDMM "* Random Cycle"
           curPalette.add("r");
           curPalette.add("r");
           curPalette.add("r");
@@ -1438,10 +1460,14 @@ void serializePalettes(JsonObject root, AsyncWebServerRequest* request)
         break;
       default:
         {
-        if (i>=palettesCount) {
-          setPaletteColors(curPalette, strip.customPalettes[i - palettesCount]);
+        if (i >= palettesCount + umPalettesCount) { // user custom palettes (lowest IDs in the custom range)
+          int custIdx = i - palettesCount - umPalettesCount;
+          setPaletteColors(curPalette, strip.customPalettes[custIdx]);
+        } else if (i >= palettesCount) { // usermod palettes (IDs 255, 254, ...)
+          int umIdx = i - palettesCount;
+          setPaletteColors(curPalette, usermodPalettes[umIdx].palette);
         } else {
-          // WLEDMM workaround for palettes index overflow at i=74 -> gGradientPalettes index=61 out of bounds.
+          // WLEDMM workaround for palettes index overflow at i=71 -> gGradientPalettes index out of bounds.
           int palIndex = i-13;
           constexpr int palMax = sizeof(gGradientPalettes)/sizeof(gGradientPalettes[0]) -1;
           if ((palIndex < 0) || (palIndex > palMax)) {
@@ -1455,6 +1481,7 @@ void serializePalettes(JsonObject root, AsyncWebServerRequest* request)
         }
         }
         break;
+
     }
   }
 }

--- a/wled00/palettes.h
+++ b/wled00/palettes.h
@@ -844,14 +844,6 @@ const byte candy2_gp[] PROGMEM = {
   211,  39, 33, 34,
   255,   1,  1,  1};
 
- //WLEDMM netmindz ar palette
-// Start off as just RGB, but replace in runtime with colors relating to the music
-const byte audio_responsive_gp[] PROGMEM = {
-   0, 255, 0, 0,
-   125, 0, 255, 0,
-   255, 0, 0, 255
-};
-
 // Single array of defined cpt-city color palettes.
 // This will let us programmatically choose one based on
 // a number, rather than having to activate each explicitly
@@ -915,10 +907,6 @@ const byte* const gGradientPalettes[] PROGMEM = {
   red_shift_gp,                 //68-55 Red Shift
   red_tide_gp,                  //69-56 Red Tide
   candy2_gp,                    //70-57 Candy2
-  // Palette contents not actually used as built on the fly, just here to create menu option
-  audio_responsive_gp,          //71-58 AudioResponsive  WLEDMM netmindz ar palette - placeholder1
-  audio_responsive_gp,          //72-59 AudioResponsive  WLEDMM netmindz ar palette - placeholder2
-  audio_responsive_gp,          //73-60 AudioResponsive  WLEDMM netmindz ar palette - placeholder3
 };
 
 #endif

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -295,11 +295,39 @@ uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLe
     } else return 0;
   }
 
-  if (src == JSON_palette_names && mode > (GRADIENT_PALETTE_COUNT + 13)) {
-    snprintf_P(dest, maxLen, PSTR("~ Custom %d ~"), 255-mode);
-    dest[maxLen] = '\0';
-    return strlen(dest);
+  if (src == JSON_palette_names) {
+    if (mode > WLED_CUSTOM_PALETTE_ID_BASE) {
+      // usermod palette (IDs 201-255)
+      uint8_t umIdx = WLED_USERMOD_PALETTE_ID_BASE - mode;
+      if (umIdx >= usermodPalettes.size()) {
+        dest[0] = '\0'; // empty string if requested index is out of bounds
+        return 0;
+      }
+      const UsermodPalette &ump = usermodPalettes[umIdx];
+      char base[33];
+      strncpy_P(base, ump.name, sizeof(base) - 1);
+      base[sizeof(base) - 1] = '\0';
+      if (ump.palName) {
+        // usermod supplied a specific display name — prefix with the usermod name (e.g. "AudioReactive: Ratio")
+        char palName[33];
+        strncpy_P(palName, ump.palName, sizeof(palName) - 1);
+        palName[sizeof(palName) - 1] = '\0';
+        snprintf(dest, maxLen + 1, "%s: %s", base, palName);
+      } else {
+        // fallback: "UMName index" (e.g. "AudioReactive 1")
+        snprintf(dest, maxLen + 1, "%s %u", base, (unsigned)ump.palIndex);
+      }
+      return strlen(dest);
+    }
+    if (mode >= FIXED_PALETTE_COUNT && mode <= WLED_CUSTOM_PALETTE_ID_BASE) {
+      // user custom palette (IDs FIXED_PALETTE_COUNT up to WLED_CUSTOM_PALETTE_ID_BASE=200)
+      snprintf_P(dest, maxLen, PSTR("~ Custom %d ~"), WLED_CUSTOM_PALETTE_ID_BASE - mode);
+      dest[maxLen] = '\0';
+      return strlen(dest);
+    }
   }
+
+
 
   uint8_t qComma = 0;
   bool insideQuotes = false;
@@ -612,35 +640,6 @@ um_data_t* simulateSound(uint8_t simulationId)
 }
 
 //WLEDMM enumerateLedmaps moved to FX_fcn.cpp
-
-//WLEDMM netmindz ar palette
-CRGB getCRGBForBand(int x, uint8_t *fftResult, int pal) { 
-  CRGB value;
-  CHSV hsv;
-  if(pal == 71) { // bit hacky to use palette id here, but don't want to litter the code with lots of different methods. TODO: add enum for palette creation type
-    if(x == 1) {
-      value = CRGB(fftResult[10]/2, fftResult[4]/2, fftResult[0]/2);
-    }
-    else if(x == 255) {
-      value = CRGB(fftResult[10]/2, fftResult[0]/2, fftResult[4]/2);
-    } 
-    else {
-      value = CRGB(fftResult[0]/2, fftResult[4]/2, fftResult[10]/2);
-    } 
-  }
-  else if(pal == 72) {
-    int b = map(x, 1, 255, 0, 10); // convert palette position to lower half of freq band
-    hsv = CHSV(fftResult[b], 255, map(fftResult[b], 0, 255, 30, 255));  // pick hue
-    hsv2rgb_rainbow(hsv, value);  // convert to R,G,B
-  }
-  else if(pal == 73) {
-    int b = map(x, 0, 255, 0, 8); // convert palette position to lower half of freq band
-    hsv = CHSV(uint8_t(fftResult[b]), 255, x);
-    hsv2rgb_rainbow(hsv, value);  // convert to R,G,B
-  }
-
-  return value;
-}
 
 /*
  * Returns a new, random color wheel index with a minimum distance of 42 from pos.

--- a/wled00/util.h
+++ b/wled00/util.h
@@ -49,7 +49,6 @@ uint16_t beatsin16_t(accum88 beats_per_minute, uint16_t lowest = 0, uint16_t hig
 uint8_t beatsin8_t(accum88 beats_per_minute, uint8_t lowest = 0, uint8_t highest = 255, uint32_t timebase = 0, uint8_t phase_offset = 0);
 
 uint8_t get_random_wheel_index(uint8_t pos);
-CRGB getCRGBForBand(int x, uint8_t *fftResult, int pal); //WLEDMM netmindz ar palette
 char *cleanUpName(char *in); // to clean up a name that was read from file
 
 uint32_t hashInt(uint32_t s);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -595,6 +595,8 @@ WLED_GLOBAL bool wasConnected _INIT(false);
 
 // color
 WLED_GLOBAL byte lastRandomIndex _INIT(0);        // used to save last random color so the new one is not the same
+WLED_GLOBAL std::vector<UsermodPalette> usermodPalettes; // WLEDMM: usermod-registered palettes (IDs 255, 254, 253...), see colors.h
+
 
 // transitions
 WLED_GLOBAL bool          transitionActive        _INIT(false);


### PR DESCRIPTION
Ports upstream WLED's usermod-palette mechanism (wled/WLED PR #5548, "Adding usermod palettes and fix UI palette display" by Damian Schneider / Will Tatam, commits fd6f56802 and follow-ups) so usermods can register their own dynamic color palettes without hijacking the user custom-palette slots.

- Add UsermodPalette struct + global usermodPalettes vector + removeUsermodPalettes() (wled00/colors.h, colors.cpp, wled.h), matching upstream's field layout (palette, name, palIndex, palName).
- New palette ID ranges, adapted to WLEDMM's existing fixed-palette set (13 fixed + 58 gradients + 1 extra "* Random Cycle" = 72):
    0-71   fixed built-in palettes (unchanged, "* Random Cycle"
           renumbered from 74 down to 71 to close the gap left by
           removing the old AR placeholder palettes)
    72-200 user custom palettes (previously 246-255)
    201-255 usermod-registered palettes (new)
- Segment::loadPalette()/setPalette(), getPaletteCount(),
  serializeInfo()/serializePalettes() (json.cpp) and
  extractModeName() (util.cpp) updated for the new ranges and to
  surface usermod palette names ("UMName: palName" or "UMName index")
  to the UI, including a new umpalcount/umpalnames JSON payload.
- wled00/data/index.js: list usermod palettes and custom palettes
  from the new fixed ID ranges; invalidate the client-side palette
  cache when the total palette count changes.
- Remove the old hardcoded AR placeholder gradient palette (IDs
  71-73) and Segment::getAudioPalette()/getCRGBForBand(), previously
  used to compute WLEDMM's audio-reactive palettes in core. These are
  superseded by the AudioReactive usermod registering its palettes
  through the new usermodPalettes API at runtime.
- platformio.ini: pin AR_lib_deps to
  netmindz/WLED-AudioReactive-Usermod@06326b0c, which implements the
  usermod side of this palette API. Drop the redundant
  softhack007/arduinoFFT fork pin (its commit ref no longer resolves
  upstream); the usermod's own library.json already depends on
  kosme/arduinoFFT 2.0.1, which its code already supports.

Breaking change: user custom palette IDs shift from 246-255 to 72-200, and the "* Random Cycle" palette moves from ID 74 to 71. Presets/segments referencing specific custom palette IDs or palette 74 will need to be re-saved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for palettes registered by user extensions, including names and color data in the palette browser and API.
  - Palette counts and custom/user-extension palette ranges are now reported dynamically.
  - Palette data refreshes when the firmware version or total palette count changes.

- **Changes**
  - Reorganized palette IDs to accommodate user-extension palettes and moved “Random Cycle” to its new position.

- **Removed**
  - Removed the three AudioResponsive palette options and their associated palette generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->